### PR TITLE
Fix division by zero in noteDensity calculation

### DIFF
--- a/src/audio/AudioAnalyzer.js
+++ b/src/audio/AudioAnalyzer.js
@@ -134,7 +134,7 @@ class AudioAnalyzer {
       averagePitch: pitches.reduce((a, b) => a + b, 0) / pitches.length,
       averageVelocity: velocities.reduce((a, b) => a + b, 0) / velocities.length,
       averageDuration: durations.reduce((a, b) => a + b, 0) / durations.length,
-      noteDensity: allNotes.length / midiData.duration,
+      noteDensity: midiData.duration > 0 ? allNotes.length / midiData.duration : 0,
       pitchVariation: this.calculatePitchVariation(pitches),
       velocityVariation: this.calculateVelocityVariation(velocities),
       rhythmComplexity: this.calculateRhythmComplexity(startTimes),

--- a/test/AudioAnalyzer.test.js
+++ b/test/AudioAnalyzer.test.js
@@ -1,0 +1,33 @@
+const assert = require('assert');
+const AudioAnalyzer = require('../src/audio/AudioAnalyzer');
+
+function runTest(name, testFunction) {
+  try {
+    testFunction();
+    console.log(`✔ ${name}`);
+  } catch (error) {
+    console.error(`✖ ${name}`);
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+runTest('extractMIDIFeatures should handle zero duration without errors', () => {
+  const analyzer = new AudioAnalyzer();
+  const midiData = {
+    duration: 0,
+    tracks: [
+      {
+        notes: [
+          { pitch: 60, velocity: 100, duration: 0, startTime: 0 }
+        ]
+      }
+    ]
+  };
+
+  const features = analyzer.extractMIDIFeatures(midiData);
+
+  assert.strictEqual(features.noteDensity, 0, 'noteDensity should be 0 for zero duration');
+});
+
+console.log('All tests passed');


### PR DESCRIPTION
In `src/audio/AudioAnalyzer.js`, the `noteDensity` was calculated by dividing by `midiData.duration`. If `midiData.duration` was 0, this would result in `Infinity`, which could cause downstream errors.

This commit adds a check to ensure `midiData.duration` is greater than 0 before performing the division. If it is 0, `noteDensity` is set to 0.

A test case has been added in `test/AudioAnalyzer.test.js` to verify that the fix works as expected.