### PR TITLE
Fix(generation): Pass analysis patterns to MIDI generator

### DIFF
--- a/llm-orchestrator.js
+++ b/llm-orchestrator.js
@@ -22,17 +22,17 @@ async function generateLlmResponse(prompt, queryVector = null, queryType = null)
     let context = "";
     let relevantSourceFiles = [];
 
+    let patterns = [];
     if (queryVector && queryType) {
-        let queryResults = [];
         if (queryType === 'humanization') {
-            queryResults = await vectorDatabase.queryHumanizationFeatures(queryVector, 3); // Get top 3
+            patterns = await vectorDatabase.queryHumanizationFeatures(queryVector, 3); // Get top 3
         } else if (queryType === 'pattern') {
-            queryResults = await vectorDatabase.queryPatternFeatures(queryVector, 3); // Get top 3
+            patterns = await vectorDatabase.queryPatternFeatures(queryVector, 3); // Get top 3
         }
 
-        if (queryResults.length > 0) {
+        if (patterns.length > 0) {
             context += "\n\n--- Relevant Musical Context from Library ---\n";
-            queryResults.forEach((res, index) => {
+            patterns.forEach((res, index) => {
                 context += `\nMatch ${index + 1} (Similarity Score: ${res._distance ? res._distance.toFixed(3) : 'N/A'}):\n`;
                 context += `  Source File: ${path.basename(res.sourceFile)}\n`;
                 context += `  Type: ${res.type}, Tags: ${res.tags.join(', ')}\n`;
@@ -69,7 +69,7 @@ async function generateLlmResponse(prompt, queryVector = null, queryType = null)
     }
 
     await new Promise(resolve => setTimeout(resolve, Math.random() * 2000 + 1000));
-    return { response, sourceFiles: relevantSourceFiles }; // Return source files as well
+    return { response, sourceFiles: relevantSourceFiles, patterns }; // Return source files and patterns
 }
 
 module.exports = {

--- a/main.js
+++ b/main.js
@@ -88,7 +88,7 @@ async function handleGeneration(generationType, prompt) {
         }
 
         const queryVector = generateQueryVector(prompt, loadedFiles);
-        const { response: llmResponse, sourceFiles } = await llmOrchestrator.generateLlmResponse(prompt, queryVector, generationType === 'humanize' ? 'humanization' : 'pattern');
+        const { response: llmResponse, sourceFiles, patterns: analysisPatterns } = await llmOrchestrator.generateLlmResponse(prompt, queryVector, generationType === 'humanize' ? 'humanization' : 'pattern');
 
         let fullLog = `LLM Response (${generationType.toUpperCase()}): ${llmResponse}`;
         if (sourceFiles && sourceFiles.length > 0) {
@@ -103,7 +103,7 @@ async function handleGeneration(generationType, prompt) {
                 fs.mkdirSync(outputDir, { recursive: true });
             }
             const outputFilePath = path.join(outputDir, `generated_midi_${Date.now()}.mid`);
-            const generatedPath = await midiGenerator.generateMidiFromLLMResponse(llmResponse, outputFilePath);
+            const generatedPath = await midiGenerator.generateMidiFromLLMResponse(llmResponse, outputFilePath, analysisPatterns);
             mainWindow.webContents.send('log-to-oled', `MIDI generated successfully: ${path.basename(generatedPath)}`);
             return { success: true, generatedPath: path.basename(generatedPath) };
         }

--- a/midi-generator.js
+++ b/midi-generator.js
@@ -3,8 +3,9 @@ const { Midi } = require('@tonejs/midi'); // For MIDI object manipulation
 const fs = require('fs/promises'); // To save the file
 const path = require('path');
 
-async function generateMidiFromLLMResponse(llmSuggestion, outputPath) {
+async function generateMidiFromLLMResponse(llmSuggestion, outputPath, analysisPatterns) {
     console.log(`MIDI Generator: Received LLM suggestion for generation: "${llmSuggestion}"`);
+    console.log('MIDI Generator: Received analysis patterns:', analysisPatterns);
     // This is a highly simplified placeholder.
     // In reality, this would involve parsing LLM text for instructions
     // and using musical theory or ML models to create notes.


### PR DESCRIPTION
The music generation process was failing with an `analysisPatterns is not defined` error because the analysis patterns fetched from the vector database were not being passed through the entire generation pipeline.

This commit fixes the issue by:
1.  Updating `llm-orchestrator.js` to return the `patterns`.
2.  Updating `main.js` to receive the `analysisPatterns` and pass them to the `midiGenerator`.
3.  Updating `midi-generator.js` to accept the `analysisPatterns` argument.

This ensures the necessary data is available to the MIDI generator, resolving the crash.